### PR TITLE
feat: allow updating of role capabilities

### DIFF
--- a/src/ResourceControllers/User.php
+++ b/src/ResourceControllers/User.php
@@ -31,8 +31,25 @@ class User extends ResourceController
     public function process()
     {
         foreach ($this->config as $role => $args) {
-            //remove_role( $role );
-            add_role($role, $args['display_name'], $args['capabilities']);
+            $wpRole = get_role($role);
+            if ($wpRole instanceof \WP_Role) {
+                $requiredCapabilities = [];
+                foreach ($args['capabilities'] as $capability => $granted) {
+                    if (true === boolval($granted)) {
+                        $requiredCapabilities[] = $capability;
+                        if (false === $wpRole->has_cap($capability)) {
+                            $wpRole->add_cap($capability);
+                        }
+                    }
+                }
+                foreach ($wpRole->capabilities as $capability => $granted) {
+                    if (false === in_array($capability, $requiredCapabilities)) {
+                        $wpRole->remove_cap($capability);
+                    }
+                }
+            } else {
+                add_role($role, $args['display_name'], $args['capabilities']);
+            }
         }
     }
 


### PR DESCRIPTION
`add_role(` makes no changes when the role already exists.

By checking for existence first, we can then add/remove capabilities as required by comparing the granted & required capabilities.

Allows adding the `upload_files` capability to Sylvera Editors without having to nuke roles